### PR TITLE
perf: use size hint when creating Chunk::Collect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.vscode

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -1,6 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tailcall_chunk::Chunk;
 
+const N: usize = 10000;
+
 fn bench_operations(c: &mut Criterion) {
     // Benchmark append operations
     c.benchmark_group("append")
@@ -78,6 +80,13 @@ fn bench_operations(c: &mut Criterion) {
                 black_box(vec.clone());
             })
         });
+
+    // Benchmark from_iter operation
+    c.benchmark_group("from_iter")
+        .bench_function("Chunk", |b| {
+            b.iter(|| Chunk::from_iter((0..N).into_iter()));
+        })
+        .bench_function("Vec", |b| b.iter(|| Vec::from_iter((0..N).into_iter())));
 }
 
 criterion_group!(benches, bench_operations);

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -349,11 +349,9 @@ impl<A> FromIterator<A> for Chunk<A> {
     /// assert_eq!(chunk.as_vec(), vec![1, 2, 3]);
     /// ```
     fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
-        let mut chunk = Vec::default();
-        for item in iter {
-            chunk.push(item);
-        }
-        Chunk::Collect(Rc::new(RefCell::new(chunk)))
+        let vec: Vec<_> = iter.into_iter().collect();
+
+        Chunk::Collect(Rc::new(RefCell::new(vec)))
     }
 }
 


### PR DESCRIPTION
Improves performance of creating Chunk::Collect

before:
```
from_iter/Chunk         time:   [7.5359 µs 7.5740 µs 7.6140 µs]
                        change: [-0.3708% +1.1167% +2.5443%] (p = 0.13 > 0.05)
                        No change in performance detected.
```
after:

```
from_iter/Chunk         time:   [1.3339 µs 1.3374 µs 1.3419 µs]
                        change: [-82.399% -82.296% -82.209%] (p = 0.00 < 0.05)
                        Performance has improved.
```