### PR TITLE
perf: make fair benchmark comparison fwii

### DIFF
--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use tailcall_chunk::Chunk;
 
 const N: usize = 10000;
@@ -6,79 +6,73 @@ const N: usize = 10000;
 fn bench_operations(c: &mut Criterion) {
     // Benchmark append operations
     c.benchmark_group("append")
-        .bench_function("chunk_append", |b| {
+        .bench_function("Chunk", |b| {
             b.iter(|| {
                 let mut chunk = Chunk::default();
-                for i in 0..10000 {
+                for i in 0..N {
                     chunk = chunk.append(i.to_string());
                 }
 
-                black_box(chunk);
+                chunk
             })
         })
-        .bench_function("vec_append", |b| {
+        .bench_function("Vec", |b| {
             b.iter(|| {
                 let mut vec = Vec::new();
-                for i in 0..10000 {
+                for i in 0..N {
                     vec.push(i.to_string());
                 }
-                black_box(vec);
+                vec
             })
         });
 
     // Benchmark prepend operations
     c.benchmark_group("prepend")
-        .bench_function("chunk_prepend", |b| {
+        .bench_function("Chunk", |b| {
             b.iter(|| {
                 let mut chunk = Chunk::default();
-                for i in 0..10000 {
+                for i in 0..N {
                     chunk = chunk.prepend(i.to_string());
                 }
-                black_box(chunk);
+                chunk
             })
         })
-        .bench_function("vec_prepend", |b| {
+        .bench_function("Vec", |b| {
             b.iter(|| {
                 let mut vec = Vec::new();
-                for i in 0..10000 {
+                for i in 0..N {
                     vec.insert(0, i.to_string());
                 }
-                black_box(vec);
+                vec
             })
         });
 
     // Benchmark concat operations
     c.benchmark_group("concat")
-        .bench_function("chunk_concat", |b| {
-            let chunk1: Chunk<_> = (0..5000).map(|i| i.to_string()).collect();
-            let chunk2: Chunk<_> = (5000..10000).map(|i| i.to_string()).collect();
-            b.iter(|| {
-                black_box(chunk1.clone().concat(chunk2.clone()));
-            })
+        .bench_function("Chunk", |b| {
+            let chunk1: Chunk<_> = (0..N / 2).map(|i| i.to_string()).collect();
+            let chunk2: Chunk<_> = (N / 2..N).map(|i| i.to_string()).collect();
+            b.iter(|| chunk1.clone().concat(chunk2.clone()))
         })
-        .bench_function("vec_concat", |b| {
-            let vec1: Vec<_> = (0..5000).map(|i| i.to_string()).collect();
-            let vec2: Vec<_> = (5000..10000).map(|i| i.to_string()).collect();
+        .bench_function("Vec", |b| {
+            let vec1: Vec<_> = (0..N / 2).map(|i| i.to_string()).collect();
+            let vec2: Vec<_> = (N / 2..N).map(|i| i.to_string()).collect();
             b.iter(|| {
                 let mut result = vec1.clone();
                 result.extend(vec2.iter().cloned());
-                black_box(result)
+                result
             })
         });
 
     // Benchmark clone operations
     c.benchmark_group("clone")
-        .bench_function("chunk_clone", |b| {
-            let chunk: Chunk<_> = (0..10000).collect();
-            b.iter(|| {
-                black_box(chunk.clone());
-            })
+        .bench_function("Chunk", |b| {
+            let chunk: Chunk<_> = (0..N).collect();
+            b.iter(|| chunk.clone())
         })
-        .bench_function("vec_clone", |b| {
-            let vec: Vec<_> = (0..10000).collect();
-            b.iter(|| {
-                black_box(vec.clone());
-            })
+        .bench_function("Vec", |b| {
+            let vec: Vec<_> = (0..N).collect();
+            b.iter(|| vec.clone())
         });
 
     // Benchmark from_iter operation

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -13,7 +13,7 @@ fn bench_operations(c: &mut Criterion) {
                     chunk = chunk.append(i.to_string());
                 }
 
-                chunk
+                chunk.as_vec()
             })
         })
         .bench_function("Vec", |b| {
@@ -22,6 +22,7 @@ fn bench_operations(c: &mut Criterion) {
                 for i in 0..N {
                     vec.push(i.to_string());
                 }
+
                 vec
             })
         });
@@ -34,7 +35,7 @@ fn bench_operations(c: &mut Criterion) {
                 for i in 0..N {
                     chunk = chunk.prepend(i.to_string());
                 }
-                chunk
+                chunk.as_vec()
             })
         })
         .bench_function("Vec", |b| {
@@ -50,16 +51,24 @@ fn bench_operations(c: &mut Criterion) {
     // Benchmark concat operations
     c.benchmark_group("concat")
         .bench_function("Chunk", |b| {
-            let chunk1: Chunk<_> = (0..N / 2).map(|i| i.to_string()).collect();
-            let chunk2: Chunk<_> = (N / 2..N).map(|i| i.to_string()).collect();
-            b.iter(|| chunk1.clone().concat(chunk2.clone()))
+            let part: Chunk<_> = (0..100).map(|i| i.to_string()).collect();
+            b.iter(|| {
+                let mut chunk = Chunk::default();
+                for _ in 0..N {
+                    chunk = chunk.concat(part.clone());
+                }
+
+                chunk.as_vec()
+            })
         })
         .bench_function("Vec", |b| {
-            let vec1: Vec<_> = (0..N / 2).map(|i| i.to_string()).collect();
-            let vec2: Vec<_> = (N / 2..N).map(|i| i.to_string()).collect();
+            let part: Vec<_> = (0..100).map(|i| i.to_string()).collect();
             b.iter(|| {
-                let mut result = vec1.clone();
-                result.extend(vec2.iter().cloned());
+                let mut result = Vec::new();
+                for _ in 0..N {
+                    result.extend(part.iter().cloned());
+                }
+
                 result
             })
         });
@@ -68,7 +77,7 @@ fn bench_operations(c: &mut Criterion) {
     c.benchmark_group("clone")
         .bench_function("Chunk", |b| {
             let chunk: Chunk<_> = (0..N).collect();
-            b.iter(|| chunk.clone())
+            b.iter(|| chunk.clone().as_vec())
         })
         .bench_function("Vec", |b| {
             let vec: Vec<_> = (0..N).collect();
@@ -78,7 +87,7 @@ fn bench_operations(c: &mut Criterion) {
     // Benchmark from_iter operation
     c.benchmark_group("from_iter")
         .bench_function("Chunk", |b| {
-            b.iter(|| Chunk::from_iter((0..N).into_iter()));
+            b.iter(|| Chunk::from_iter((0..N).into_iter()).as_vec());
         })
         .bench_function("Vec", |b| b.iter(|| Vec::from_iter((0..N).into_iter())));
 }


### PR DESCRIPTION
The previous benchmark implementation was focused only on the called operations itself ignoring the part of deferred calculation that actually should be done to be able to use the calculated result.

Why is it important? To make the comparison more fair since when using Vec and its methods we get the entity that could be used immediately for acquiring the specific values or iterating over. But for `Chunk` we need to call `.as_vec` method before we can use similar things.

It changes the results significantly and could represent downsides of using `Chunk` more clearly.

Here are the results on my machine:

```
append/Chunk            time:   [1.0212 ms 1.0430 ms 1.0703 ms]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
append/Vec              time:   [481.98 µs 483.49 µs 485.36 µs]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

Benchmarking prepend/Chunk: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.0s, enable flat sampling, or reduce sample count to 50.
prepend/Chunk           time:   [1.7710 ms 1.7810 ms 1.7927 ms]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
prepend/Vec             time:   [16.131 ms 16.282 ms 16.461 ms]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

Benchmarking concat/Chunk: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.1s, or reduce sample count to 90.
concat/Chunk            time:   [51.900 ms 52.134 ms 52.406 ms]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
Benchmarking concat/Vec: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.5s, or reduce sample count to 90.
concat/Vec              time:   [50.810 ms 51.041 ms 51.352 ms]
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe

clone/Chunk             time:   [1.8813 µs 1.9128 µs 1.9514 µs]
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
clone/Vec               time:   [1.3566 µs 1.3694 µs 1.3856 µs]
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

from_iter/Chunk         time:   [3.2536 µs 3.2681 µs 3.2904 µs]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
from_iter/Vec           time:   [1.3630 µs 1.3896 µs 1.4259 µs]
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe
```